### PR TITLE
Bug/4141 zoom while hover causes jitter

### DIFF
--- a/src/plugins/hover.ts
+++ b/src/plugins/hover.ts
@@ -139,7 +139,6 @@ class HoverPlugin extends BasePlugin<HoverPluginEvents, HoverPluginOptions> {
     // Position
     const bbox = this.wavesurfer.getWrapper().getBoundingClientRect()
     const { width } = bbox
-
     const offsetX = e.clientX - bbox.left
     const relX = Math.min(1, Math.max(0, offsetX / width))
     const posX = Math.min(width - this.options.lineWidth - 1, offsetX)

--- a/src/plugins/hover.ts
+++ b/src/plugins/hover.ts
@@ -158,6 +158,7 @@ class HoverPlugin extends BasePlugin<HoverPluginEvents, HoverPluginOptions> {
 
   private onPointerLeave = () => {
     this.wrapper.style.opacity = '0'
+    this.lastPointerMove = null
   }
 
   /** Unmount */


### PR DESCRIPTION
## Short description
Resolves #4141 in main wavesurfer library.

Issue was that while zoomPlugin was activated with mousewheel WHILE hovering the waveform, the hover line would jitter about.

## Implementation details
- Ensure that hover is updated NOT on wheel, BUT on zoom and scroll events.

## How to test it


## Screenshots


## Checklist
* [ ] This PR is covered by e2e tests
* [ ] It introduces no breaking API changes
